### PR TITLE
making Bubbls Smaller When Sidebar is Closed

### DIFF
--- a/sidebar-expand-on-hover/chrome.css
+++ b/sidebar-expand-on-hover/chrome.css
@@ -264,6 +264,10 @@
             display: flex !important;
         }
     }
+    
+    #zen-sidebar-top-buttons-separator {
+        display: none !important;
+    }
 
     #zen-workspaces-button {
         flex-direction: row !important;

--- a/sidebar-expand-on-hover/chrome.css
+++ b/sidebar-expand-on-hover/chrome.css
@@ -264,10 +264,6 @@
             display: flex !important;
         }
     }
-    
-    #zen-sidebar-top-buttons-separator {
-        display: none !important;
-    }
 
     #zen-workspaces-button {
         flex-direction: row !important;
@@ -330,4 +326,20 @@
     #navigator-toolbox:not([zen-has-hover], [has-popup-menu], [movingtab]) #zen-sidebar-bottom-buttons {
         flex-direction: column !important;
     }
+    .zen-workspace-tabs-section {
+        display: flex;
+        flex-direction: column;
+        max-width: 100% !important;
+        overflow: hidden;
+      }
+    #tabbrowser-tabs[orient="vertical"] {
+        justify-content: center;
+        overflow: hidden;
+        max-width: 100%;
+        box-sizing: border-box;
+    }
+    #navigator-toolbox:not([zen-has-hover], [has-popup-menu], [movingtab]) vbox.tab-background {
+        width: 80% !important;
+    }
+  
 }

--- a/sidebar-expand-on-hover/chrome.css
+++ b/sidebar-expand-on-hover/chrome.css
@@ -333,7 +333,6 @@
         overflow: hidden;
       }
     #tabbrowser-tabs[orient="vertical"] {
-        justify-content: center;
         overflow: hidden;
         max-width: 100%;
         box-sizing: border-box;
@@ -341,5 +340,4 @@
     #navigator-toolbox:not([zen-has-hover], [has-popup-menu], [movingtab]) vbox.tab-background {
         width: 80% !important;
     }
-  
 }


### PR DESCRIPTION
before:
![2025-02-26-185020_hyprshot](https://github.com/user-attachments/assets/e6399230-2828-46c3-b69b-c1175d0119d6)
after:
![2025-02-26-185034_hyprshot](https://github.com/user-attachments/assets/9a85062a-5e5d-4883-9620-dba2e46d1e86)
without zen-mods enabled: 
![2025-02-26-185230_hyprshot](https://github.com/user-attachments/assets/1daf679e-5a1e-4fd8-88cb-c3670ccfcc46)

remaining issue with plugin:
![2025-02-26-185305_hyprshot](https://github.com/user-attachments/assets/52a5fc98-4797-46b0-8652-61acd0e67057)
 "Now playing indicator (v1.2.1)" plugins side bar is not placed right